### PR TITLE
Add conditional back button to stats bar

### DIFF
--- a/app/build/components/BuildPageContent.tsx
+++ b/app/build/components/BuildPageContent.tsx
@@ -838,6 +838,8 @@ export function BuildPageContent() {
             onNodesChange([{ type: 'add', item: roiNode }]);
             console.log('📊 BuildPageContent: Called onNodesChange');
           }}
+          isAnalyticsView={activeTab === 'analytics'}
+          onGoBackToCanvas={() => setActiveTab('canvas')}
         />
 
         {/* Content */}

--- a/app/build/components/BuildPageCore.tsx
+++ b/app/build/components/BuildPageCore.tsx
@@ -656,6 +656,8 @@ export function BuildPageCore({ scenarioIdParam, templateIdParam, queryParam }: 
                 selectedIds={selectedIds}
                 selectedGroupId={selectedGroupId}
                 isMultiSelectionActive={isMultiSelectionActive}
+                isAnalyticsView={activeTab === 'analytics'}
+                onGoBackToCanvas={() => setActiveTab('canvas')}
               />
 
               {/* Main content with lazy loading */}

--- a/components/flow/StatsBar.tsx
+++ b/components/flow/StatsBar.tsx
@@ -26,7 +26,8 @@ import {
   CheckSquare,
   Sun,
   Moon,
-  Timer
+  Timer,
+  ArrowLeft
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PlatformType, Scenario } from "@/lib/types";
@@ -76,6 +77,10 @@ interface StatsBarProps {
   
   // ROI Report generation
   onGenerateROIReport?: (node: Node) => void;
+
+  // View state
+  isAnalyticsView?: boolean;
+  onGoBackToCanvas?: () => void;
 }
 
 // Platform configurations
@@ -153,6 +158,8 @@ export function StatsBar({
   isMultiSelectionActive = false,
   currentScenario,
   onGenerateROIReport,
+  isAnalyticsView = false,
+  onGoBackToCanvas,
 }: StatsBarProps) {
   const { theme, setTheme } = useTheme();
   const [isMounted, setIsMounted] = useState(false);
@@ -1001,6 +1008,17 @@ export function StatsBar({
           <h1 className="text-lg font-display font-bold tracking-tight text-foreground">
             Apicus.io
           </h1>
+          {isAnalyticsView && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 ml-3"
+              onClick={() => onGoBackToCanvas?.()}
+            >
+              <ArrowLeft className="h-4 w-4 mr-1" />
+              Go back
+            </Button>
+          )}
         </div>
 
                   {/* Center - Stats */}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -224,6 +224,22 @@ export interface StatsBarProps {
   onUpdateMinutes: (minutes: number) => void;
   nodes?: Node[];
   currentScenario?: unknown;
+
+  // Optional controls used in some contexts
+  onPlatformChange?: (platform: PlatformType) => void;
+  onOpenROISettings?: () => void;
+  onAddNode?: () => void;
+  onGenerateEmail?: () => void;
+  isGeneratingEmail?: boolean;
+  onCreateGroup?: () => void;
+  onUngroup?: () => void;
+  selectedIds?: string[];
+  selectedGroupId?: string | null;
+  isMultiSelectionActive?: boolean;
+
+  // View state
+  isAnalyticsView?: boolean;
+  onGoBackToCanvas?: () => void;
 }
 
 export interface PlatformSwitcherProps {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -358,6 +358,10 @@ export interface StatsBarProps {
   selectedIds?: string[];
   selectedGroupId?: string | null;
   isMultiSelectionActive?: boolean;
+
+  // View state controls
+  isAnalyticsView?: boolean;
+  onGoBackToCanvas?: () => void;
 }
 
 export interface PlatformSwitcherProps {


### PR DESCRIPTION
Add a "Go back" button to the StatsBar to allow users to return from the analytics view to the canvas.

---
<a href="https://cursor.com/background-agent?bcId=bc-c18bd1bf-a386-4041-8848-5af2d94b249f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c18bd1bf-a386-4041-8848-5af2d94b249f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

